### PR TITLE
ignore case for pasted scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
             document.getElementById("name").innerText = searchParams.get("n") || searchParams.get("g") || searchParams.get("a");
 
             if (isValid && document.querySelector('section').classList.contains('hidden')) {
-                document.querySelector('.share-link').setAttribute('href', '#' + inputData.replace('OPENPGP4FPR:', '').replace('#', '&'))
+                document.querySelector('.share-link').setAttribute('href', '#' + inputData.replace(/openpgp4fpr:/i, '').replace('#', '&'))
                 return document.querySelector('.share-link').classList.remove('hidden');
             }
 


### PR DESCRIPTION
data pasted to the form may contain `openpgp4fpr:` (strict format) as well as `OPENPGP4FPR:` (variant, used for $reasons).

just accept both when generating the link on i.delta.chat

closes #14 - this pr is about fixing parsing pasted input only - the generated link still is uppercase `OPENPGP4FPR:` which might not be 100% correct