### PR TITLE
Create apple-app-site-association for deep linking on iOS (and maybe also macOS)

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["chat.delta", "chat.delta.desktop.electron"],
+        "components": [
+          {
+            "#": "*&i*",
+            "comment": "Matches any URL with a fragment that contains &i and instructs the system to open it"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I followed the instructions at https://developer.apple.com/documentation/xcode/supporting-associated-domains

I need to have this file available to test my local iOS code before I can publish it as a pr.


related: 
- https://github.com/deltachat/deltachat-ios/issues/2065
- https://github.com/deltachat/deltachat-desktop/issues/3657