### PR TITLE
fix deployment GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         owner: 'deltachat'
         repository: 'invite'
-    - run: ls -la && ls -la invite
+    - run: rm -rf invite/.git
     - name: Upload
       uses: horochx/deploy-via-scp@1.1.0
       with:


### PR DESCRIPTION
In .git are files without write permissions, deployment fails when it tries to overwrite them. Deleting .git before upload seems to help, we don't need it anyway.