### PR TITLE
Add app clips configuration to association file

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -11,5 +11,8 @@
         ]
       }
     ]
+  },
+  "appclips": {
+    "apps": ["8Y86453UA8.chat.delta.Clip"]
   }
 }


### PR DESCRIPTION
This is needed for the iOS invite clip. It is currently at concept stage but this aasa change is needed for testing it. 