### PR TITLE
Add polish translation

### DIFF
--- a/i18n/pl.js
+++ b/i18n/pl.js
@@ -1,0 +1,17 @@
+Object.assign((typeof window === 'undefined' ? module.exports : window).i18n = (typeof window === 'undefined' ? module.exports : window).i18n || {}, {
+  pl: {
+    TitleText: 'Połącz się przez Delta Chat',
+    DescriptionText: 'Delta Chat jest aplikacją działająca na bazie e-mail',
+    FormBlurbText: 'Stwórz zaproszenie do Delta Chat',
+    StepCodeText: 'Otwórz Delta Chat, następnie przejdź do <b>QR kod → Pokaż QR kod zaproszenia → Skopiuj do schowka</b>',
+    StepPasteText: 'Wklej w to pole:',
+    StepShareText: 'Udostępnij wygenerowany link przez inne kanały',
+    ShareLinkText: 'Otwórz link',
+    JoinText: 'Powiedz cześć',
+    JoinGroupText: 'Dołącz',
+    ChatText: 'Otwórz czat',
+    DownloadText: 'Pobierz Delta Chat',
+    OtherDeviceText: 'Naciśnij jeśli masz Delta Chat na innym urządzeniu',
+    ScanQRText: 'Zeskanuj, aby otworzyć czat na innym urządzeniu',
+  },
+});

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <script src="./i18n/de.js"></script>
     <script src="./i18n/en.js"></script>
     <script src="./i18n/fr.js"></script>
+    <script src="./i18n/pl.js"></script>
     <script src="./i18n/ru.js"></script>
 
     <style>


### PR DESCRIPTION
Someone on the "Delta Chat"-forum [translated this, and requested, that someone else does add it](https://support.delta.chat/t/the-invitation-webpages-should-be-translated-to-more-languages/5181/6), because they do not have a GitHub-account.

I do not understand Polish, but according to automatic translation by DeepL and the translation-feature of Firefox, it seems sufficiently correct to be understandable.