### PR TITLE
ci: use rsync for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
         mkdir -p "$HOME/.ssh"
         echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
         chmod 600 "$HOME/.ssh/key"
-        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite/* "${{ secrets.USERNAME }}@i.delta.chat:"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite/ "${{ secrets.USERNAME }}@i.delta.chat:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
         mkdir -p "$HOME/.ssh"
         echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
         chmod 600 "$HOME/.ssh/key"
-        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite "${{ secrets.USERNAME }}@delta.chat:/var/www/html/"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite/* "${{ secrets.USERNAME }}@i.delta.chat:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     - run: rm -rf invite/.git
     - name: Upload
       run: |
-        mkdir -p "$HOME/.ssh"
+        mkdir -m 700 -p "$HOME/.ssh"
         echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
         chmod 600 "$HOME/.ssh/key"
         rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite/ "${{ secrets.USERNAME }}@i.delta.chat:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,8 @@ jobs:
         repository: 'invite'
     - run: rm -rf invite/.git
     - name: Upload
-      uses: horochx/deploy-via-scp@c82b42f002701aeca107ef7cf6ea4efe6788141e  # 1.1.0
-      with:
-        user: ${{ secrets.USERNAME }}
-        key: ${{ secrets.KEY }}
-        host: "delta.chat"
-        port: 22
-        local: "invite"
-        remote: "/var/www/html/"
-
+      run: |
+        mkdir -p "$HOME/.ssh"
+        echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
+        chmod 600 "$HOME/.ssh/key"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/invite "${{ secrets.USERNAME }}@delta.chat:/var/www/html/"


### PR DESCRIPTION
This is necessary because https://github.com/deltachat/sysadmin/issues/270 switches our server-side authentication to rrsync and scp won't work anymore.

We need to re-run CI after migrating page to www.